### PR TITLE
حل مشکل کد تایپ‌اسکریپت در مثال الگوی‌طراحی ویزیتور

### DIFF
--- a/README.md
+++ b/README.md
@@ -9296,7 +9296,7 @@ class Dolphin implements Animal {
     }
 }
 
-class Speak extends AnimalOperation {
+class Speak implements AnimalOperation {
     visitMonkey(monkey: Monkey) {
         monkey.shout();
     }


### PR DESCRIPTION
یک مشکل سینتکسی کوچک در مثال تایپ‌اسکریپت ویزیتور وجود داشت و کلمه کلیدی `extends` به جای کلمه کلیدی `implements` استفاده شده بود.