### PR TITLE
Improve php example for proxy design pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -6126,6 +6126,12 @@ class SecuredDoor implements DoorInterface {
     $this->door->close();
   }
 }
+
+$door = new SecuredDoor(new LabDoor());
+$door->open('invalid');  // Big no! It ain't possible
+
+$door->open('$ecr@t');  // Opening lab door
+$door->close();  // Closing lab door
 ```
 
 </div>


### PR DESCRIPTION
The PHP example for proxy design pattern was missing the implementation of the classes. I added it.